### PR TITLE
Bug Fix: item gets "stuck" to mouse

### DIFF
--- a/bala.DualSelectList/js/bala.DualSelectList.jquery.js
+++ b/bala.DualSelectList/js/bala.DualSelectList.jquery.js
@@ -165,8 +165,7 @@
 			});
 
 			// Hotfix bug where sometimes the item won't drop and will stick to the mouse
-			// When keyup on document and isPickup is true,
-			// -- if the escape key pressed, drop back to original location
+			// When isPickup && isMoving && escape is pressed, drop the item in the nearest panel
 			$(document).on('keyup', function(event) {
 				if(isPickup && isMoving && event.keyCode === 27) {
 					// console.log(thisSelect);

--- a/bala.DualSelectList/js/bala.DualSelectList.jquery.js
+++ b/bala.DualSelectList/js/bala.DualSelectList.jquery.js
@@ -164,6 +164,33 @@
 				thisItemNull.appendTo(thisMain).hide();
 			});
 
+			// Hotfix bug where sometimes the item won't drop and will stick to the mouse
+			// When keyup on document and isPickup is true,
+			// -- if the escape key pressed, drop back to original location
+			$(document).on('keyup', function(event) {
+				if(isPickup && isMoving && event.keyCode === 27) {
+					// console.log(thisSelect);
+					var target = findItemLocation(thisSelect);
+				    if (target.targetItem == null) {
+                        thisSelect.css({
+                            'position': 'initial',
+                            'z-index': 'initial',
+                            'width': 'calc(100% - 16px)'
+                        }).appendTo(target.targetPanel);
+				    } else {
+                        thisSelect.css({
+                            'position': 'initial',
+                            'z-index': 'initial',
+                            'width': 'calc(100% - 16px)'
+                        }).insertAfter(target.targetItem);
+				    }
+
+				    isPickup = false;
+				    isMoving = false;
+				    thisItemNull.appendTo(thisMain).hide();
+				}
+			});
+			
 			// When Clicking on the filter, remove the hint text
 			$(document).on('focus', 'input.dsl-filter-input', function() {
 				var fltText = $(this).val();


### PR DESCRIPTION
I had integrated this plugin into my website and found a bug where sometimes when I drop the item, it won't actually drop and it gets "stuck" to my mouse and I can't let go of the item I'm dragging.

This fix adds the ability for the user to press escape and it will drop the item into the nearest panel.

I'm not sure if anyone else ran into this problem, but I think it is a good backup plan just in case!